### PR TITLE
feat: streaming market refresh, custom RPC, and rate limit retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 2026-02-16
+## [1.1.0] - 2026-02-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-02-16
+
+### Added
+
+- **Custom RPC support**: Set `rpcUrl` in `~/.pmarket-cli/config.json` to use an alternative Polygon RPC provider (falls back to `polygon-rpc.com` if not set)
+- **Streaming market refresh**: New `fetchAllMarketsStreaming()` method writes each page (1000 markets) directly to SQLite instead of accumulating all markets in memory — prevents OOM crash (V8 heap abort) on 440k+ markets
+- **Rate limit retry with backoff**: API calls retry up to 5 times with exponential backoff (5s increments) on errors or empty responses
+- **Page delay**: 200ms delay between pages during refresh to avoid hitting CLOB API rate limits
+
+### Changed
+
+- `RefreshStrategy` now clears cache before refresh and uses streaming method
+- `fetchAllMarkets()` also has retry logic (used by `getMarketsAcceptingOrders()`)
+
+### Fixed
+
+- V8 heap abort (exit code 134) when refreshing full market cache with 440k+ markets
+
 ## [0.9.0] - 2026-02-05
 
 ### ⚠️ BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ That's it! The tool will:
 - Use a public Polygon RPC (`https://polygon-rpc.com`) by default
 - Auto-generate and cache API credentials on first use
 
+### Optional: Custom RPC Provider
+
+By default, `pmarket-cli` uses `https://polygon-rpc.com`. To use a different Polygon RPC provider, add `rpcUrl` to your config file (`~/.pmarket-cli/config.json`):
+
+```json
+{
+    "privateKey": "your-private-key",
+    "rpcUrl": "https://polygon-bor-rpc.publicnode.com"
+}
+```
+
+This is useful if the default RPC is slow, rate-limited, or unreliable in your region.
+
 ### Optional: Generate API Keys Manually
 
 If you want to see or regenerate your API keys:
@@ -357,7 +370,7 @@ All configuration is stored in `~/.pmarket-cli/`:
 
 | File | Purpose |
 |------|---------|
-| `config.json` | Your private key |
+| `config.json` | Private key and settings (e.g. `rpcUrl`) |
 | `credentials.json` | Auto-generated API credentials |
 | `cache.db` | SQLite cache for market data |
 

--- a/src/services/config.service.spec.ts
+++ b/src/services/config.service.spec.ts
@@ -1,7 +1,27 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 describe('ConfigService', () => {
-    it('should return default RPC provider', async () => {
+    let tmpDir: string;
+    const origEnv = process.env.PMARKET_CONFIG_DIR;
+
+    beforeAll(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), 'pmarket-test-'));
+        process.env.PMARKET_CONFIG_DIR = tmpDir;
+    });
+
+    afterAll(() => {
+        if (origEnv === undefined) {
+            delete process.env.PMARKET_CONFIG_DIR;
+        } else {
+            process.env.PMARKET_CONFIG_DIR = origEnv;
+        }
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should return default RPC provider when no rpcUrl configured', async () => {
         const { ConfigService } = await import('./config.service.js');
         const configService = new ConfigService();
         expect(configService.getRpcProvider()).toBe('https://polygon-rpc.com');
@@ -10,7 +30,6 @@ describe('ConfigService', () => {
     it('should return true for isConfigAvailable when config exists', async () => {
         const { ConfigService } = await import('./config.service.js');
         const configService = new ConfigService();
-        // The config file is created on first run, so this should be true
         expect(configService.isConfigAvailable()).toBe(true);
     });
 
@@ -24,20 +43,25 @@ describe('ConfigService', () => {
         const { ConfigService } = await import('./config.service.js');
         const configService = new ConfigService();
         expect(typeof configService.getConfigDir()).toBe('string');
-        expect(configService.getConfigDir()).toContain('.pmarket-cli');
     });
 
     it('should return null for getCreds when no credentials file exists', async () => {
-        // This test depends on whether the user has credentials
-        // In a clean install, this should be null
         const { ConfigService } = await import('./config.service.js');
         const configService = new ConfigService();
-        const creds = configService.getCreds();
-        // Either null or an object with key/secret/passphrase
-        if (creds !== null) {
-            expect(creds).toHaveProperty('key');
-            expect(creds).toHaveProperty('secret');
-            expect(creds).toHaveProperty('passphrase');
-        }
+        expect(configService.getCreds()).toBeNull();
+    });
+
+    it('should use custom rpcUrl from config when set', async () => {
+        const { ConfigService } = await import('./config.service.js');
+        const { writeFileSync } = await import('fs');
+        const configService = new ConfigService();
+        // Write a config with rpcUrl
+        writeFileSync(configService.getConfigPath(), JSON.stringify({
+            privateKey: '',
+            rpcUrl: 'https://custom-rpc.example.com'
+        }));
+        // Create new instance to pick up changed config
+        const configService2 = new ConfigService();
+        expect(configService2.getRpcProvider()).toBe('https://custom-rpc.example.com');
     });
 });

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -11,6 +11,7 @@ const DEFAULT_RPC_PROVIDER = 'https://polygon-rpc.com';
 
 interface Config {
     privateKey: string;
+    rpcUrl?: string;
 }
 
 interface Credentials {
@@ -73,7 +74,7 @@ export class ConfigService {
     }
 
     getRpcProvider(): string {
-        return DEFAULT_RPC_PROVIDER;
+        return this.config.rpcUrl || DEFAULT_RPC_PROVIDER;
     }
 
     getFunderAddress(): string {

--- a/src/services/polymarket.service.ts
+++ b/src/services/polymarket.service.ts
@@ -2,6 +2,7 @@ import { ClobClient, ApiKeyCreds, Chain, OrderType, Side } from "@polymarket/clo
 import { ethers } from "ethers";
 import axios from "axios";
 import { ConfigService } from "./config.service.js";
+import { CacheService } from "./cache.service.js";
 
 const CLOB_API_ENDPOINT = "https://clob.polymarket.com/";
 const DATA_API_ENDPOINT = "https://data-api.polymarket.com";
@@ -163,9 +164,35 @@ export class PolymarketService {
 
     const allMarkets: Market[] = [];
     let nextCursor = "";
+    let retries = 0;
 
     while (true) {
-      const response: MarketsResponse = await this.clobClient.getMarkets(nextCursor);
+      let response: MarketsResponse;
+      try {
+        response = await this.clobClient.getMarkets(nextCursor);
+      } catch (e) {
+        if (retries < 5) {
+          retries++;
+          const wait = retries * 5000;
+          console.log(`Rate limited, waiting ${wait / 1000}s (retry ${retries}/5)...`);
+          await new Promise(r => setTimeout(r, wait));
+          continue;
+        }
+        throw e;
+      }
+
+      if (!response || !response.data) {
+        if (retries < 5) {
+          retries++;
+          const wait = retries * 5000;
+          console.log(`Empty response, waiting ${wait / 1000}s (retry ${retries}/5)...`);
+          await new Promise(r => setTimeout(r, wait));
+          continue;
+        }
+        break;
+      }
+
+      retries = 0;
       allMarkets.push(...response.data);
 
       if (response.next_cursor === "LTE=" || !response.next_cursor) {
@@ -173,9 +200,67 @@ export class PolymarketService {
       }
 
       nextCursor = response.next_cursor;
+      await new Promise(r => setTimeout(r, 200));
     }
 
     return allMarkets;
+  }
+
+  async fetchAllMarketsStreaming(cacheService: CacheService): Promise<number> {
+    await this.ensureInitialized();
+    if (!this.clobClient) {
+      throw new Error("CLOB client not initialized");
+    }
+
+    let nextCursor = "";
+    let retries = 0;
+    let totalCount = 0;
+    let pageNum = 0;
+
+    while (true) {
+      let response: MarketsResponse;
+      try {
+        response = await this.clobClient.getMarkets(nextCursor);
+      } catch (e) {
+        if (retries < 5) {
+          retries++;
+          const wait = retries * 5000;
+          console.log(`Rate limited, waiting ${wait / 1000}s (retry ${retries}/5)...`);
+          await new Promise(r => setTimeout(r, wait));
+          continue;
+        }
+        throw e;
+      }
+
+      if (!response || !response.data) {
+        if (retries < 5) {
+          retries++;
+          const wait = retries * 5000;
+          console.log(`Empty response, waiting ${wait / 1000}s (retry ${retries}/5)...`);
+          await new Promise(r => setTimeout(r, wait));
+          continue;
+        }
+        break;
+      }
+
+      retries = 0;
+      pageNum++;
+      totalCount += response.data.length;
+
+      // Write each page directly to SQLite to avoid OOM on 440k+ markets
+      cacheService.cacheMarkets(response.data);
+      process.stdout.write(`\rFetched page ${pageNum} (${totalCount} markets)...`);
+
+      if (response.next_cursor === "LTE=" || !response.next_cursor) {
+        break;
+      }
+
+      nextCursor = response.next_cursor;
+      await new Promise(r => setTimeout(r, 200));
+    }
+
+    console.log('');
+    return totalCount;
   }
 
   async getMarketsAcceptingOrders(): Promise<Array<{ yes: Token; no: Token; question: string }>> {

--- a/src/strategy/context.spec.ts
+++ b/src/strategy/context.spec.ts
@@ -49,6 +49,7 @@ describe('Context', () => {
 
         jest.spyOn(polymarketService, 'getMarketsAcceptingOrders').mockImplementation(() => Promise.resolve([]));
         jest.spyOn(polymarketService, 'fetchAllMarkets').mockImplementation(() => Promise.resolve([]));
+        jest.spyOn(polymarketService, 'fetchAllMarketsStreaming').mockImplementation(() => Promise.resolve(0));
         jest.spyOn(polymarketService, 'marketOrder').mockImplementation(() => Promise.resolve({}));
         jest.spyOn(polymarketService, 'getOrderBook').mockImplementation(() => Promise.resolve({}));
         jest.spyOn(polymarketService, 'cancelAll').mockImplementation(() => Promise.resolve({}));
@@ -129,8 +130,8 @@ describe('Context', () => {
         expect(strategy).toBeDefined();
         context.setStrategy(strategy!);
         await context.executeStrategy(options);
-        expect(polymarketService.fetchAllMarkets).toHaveBeenCalled();
-        expect(cacheService.cacheMarkets).toHaveBeenCalled();
+        expect(cacheService.clearCache).toHaveBeenCalled();
+        expect(polymarketService.fetchAllMarketsStreaming).toHaveBeenCalled();
     });
 
     it('should use InitStrategy', async () => {

--- a/src/strategy/refresh-strategy.ts
+++ b/src/strategy/refresh-strategy.ts
@@ -10,11 +10,8 @@ export class RefreshStrategy implements Strategy {
 
     async execute(): Promise<void> {
         console.log('Fetching market data from Polymarket...');
-        const allMarkets = await this.polymarketService.fetchAllMarkets();
-
-        this.cacheService.cacheMarkets(allMarkets);
-
-        const activeCount = allMarkets.filter(m => m.active && !m.closed).length;
-        console.log(`Cache refreshed: ${allMarkets.length} total markets, ${activeCount} active.`);
+        this.cacheService.clearCache();
+        const totalCount = await this.polymarketService.fetchAllMarketsStreaming(this.cacheService);
+        console.log(`Cache refreshed: ${totalCount} total markets.`);
     }
 }


### PR DESCRIPTION
## Changes

### Streaming market refresh (fixes OOM crash)
- New `fetchAllMarketsStreaming()` method writes each page (1000 markets) directly to SQLite instead of accumulating 440k+ markets in memory
- `RefreshStrategy` now uses streaming method with `clearCache()` before refresh
- Fixes V8 heap abort (exit code 134) when refreshing full market cache

### Custom RPC support
- `getRpcProvider()` now reads `rpcUrl` from `~/.pmarket-cli/config.json`
- Falls back to default `polygon-rpc.com` if not set
- Allows using alternative RPC providers (e.g. `publicnode.com`)

### Rate limit retry with backoff
- Retries up to 5 times with exponential backoff (5s increments) on API errors or empty responses
- 200ms delay between pages to avoid hitting CLOB API rate limits (60 req/10s)

## Files changed
- `src/services/config.service.ts` — added `rpcUrl` to Config interface + use in `getRpcProvider()`
- `src/services/polymarket.service.ts` — retry logic in `fetchAllMarkets()` + new `fetchAllMarketsStreaming()`
- `src/strategy/refresh-strategy.ts` — use streaming refresh with cache clear